### PR TITLE
changes ce::os::debug_out() to use OutputDebugStringA

### DIFF
--- a/lib/os_win32.cpp
+++ b/lib/os_win32.cpp
@@ -64,11 +64,15 @@ namespace ce
     {
         void debug_out(char const text[])
         {
-            if (text == nullptr)
-                return;
+            // OutputDebugString is natively an A (ASCII) function
+            // ce assumes char* s are utf8 stringz
+            // so just pass it and hope for the best
+            // the debugger handles anything but doesn't print utf8
+            // see: http://unixwiz.net/techtips/outputdebugstring.html
+            // or step through OutputDebugStringW in a debugger...
 
-            CE_TO_UTF16(os_text, text);
-            OutputDebugStringW(os_text);
+
+            OutputDebugStringA(text);
         }
 
         uint64_t monotonic_timestamp()

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -86,6 +86,11 @@ GTEST_TEST(ce, main)
     }
 #endif
 
+    //char garbage[256];
+    //char c = 255;
+    //for (auto& g : garbage) g = c--;
+    //ce::os::debug_out(garbage);
+    ce::os::debug_out(u8"z\u6c34\U0001d10b");
     CE_LOG(0);
     CE_LOG(info, "Hello World", a, a * a, a / a, a + a, a - a, a + 1, a + 2, a + 3, a + 4, a + 5);
     CE_LOG(snowball, "Hello Snowball");


### PR DESCRIPTION
OutputDebugStringW was coverting to ASCII internally anyhow this also fixes a stackoverflow trying to output long strings